### PR TITLE
Add bakery demand planner skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# bakery
+# Bakery Demand AI App
+
+This repository contains a prototype application for predicting product demand in bakery branches. The project consists of a React + Vite frontend and a FastAPI backend written in Python.
+
+## Frontend
+The frontend lives in the `frontend/` directory and uses React with Vite. It provides a minimal interface to interact with the backend.
+
+### Available Scripts
+- `npm run dev` – start the development server
+- `npm run build` – build the production bundle
+- `npm run preview` – preview the production build
+
+Install dependencies with `npm install` inside the `frontend` folder.
+
+## Backend
+The backend lives in the `backend/` directory and uses FastAPI. It exposes a `/predict` endpoint that accepts a branch name and number of days to forecast. Example usage:
+
+```bash
+uvicorn main:app --reload
+```
+
+Install dependencies from `backend/requirements.txt` using `pip`.
+
+## Purpose
+The app is an early prototype that will help bakery managers plan the demand for bread, pastries and other goods for the next days.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+class DemandRequest(BaseModel):
+    branch: str
+    days_ahead: int
+
+app = FastAPI()
+
+@app.post('/predict')
+def predict_demand(req: DemandRequest):
+    predictions = [
+        {'day': i + 1, 'bread': 20 * (i + 1), 'pastry': 10 * (i + 1)}
+        for i in range(req.days_ahead)
+    ]
+    return {'branch': req.branch, 'predictions': predictions}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pydantic

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Bakery Demand Planner</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.0.4"
+  }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const App = () => {
+  return (
+    <div>
+      <h1>Bakery Demand Planner</h1>
+      <p>Plan daily demand for your bakery branches.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- set up minimal React + Vite frontend
- add FastAPI backend skeleton with demand prediction endpoint
- document how to run frontend and backend

## Testing
- `npm init -y` *(frontend)*
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68453283e958832596253b123e0c1df7