### PR TITLE
Add basic planning dashboard and API

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,10 @@
   "type": "module",
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.1"
   },
   "devDependencies": {
     "vite": "^5.2.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,24 @@
 import React from 'react';
+import { Routes, Route, Link } from 'react-router-dom';
+import Dashboard from './Dashboard.jsx';
+import PlanPage from './PlanPage.jsx';
+import OrdersPage from './OrdersPage.jsx';
+import DisplayCasePage from './DisplayCasePage.jsx';
 
 const App = () => {
   return (
     <div>
       <h1>Bakery Demand Planner</h1>
-      <p>Plan daily demand for your bakery branches.</p>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/plan" element={<PlanPage />} />
+        <Route path="/orders" element={<OrdersPage />} />
+        <Route path="/display" element={<DisplayCasePage />} />
+        <Route path="*" element={<p>Seite nicht gefunden</p>} />
+      </Routes>
+      <footer style={{ marginTop: '2em' }}>
+        <Link to="/">Home</Link>
+      </footer>
     </div>
   );
 };

--- a/frontend/src/Dashboard.jsx
+++ b/frontend/src/Dashboard.jsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+const Dashboard = () => {
+  const [tasks, setTasks] = useState([]);
+
+  useEffect(() => {
+    fetch('/tasks')
+      .then(res => res.json())
+      .then(setTasks)
+      .catch(() => setTasks([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Dashboard</h2>
+      <ul>
+        {tasks.map(t => (
+          <li key={t.id}>{t.title} (fällig am {t.due_date})</li>
+        ))}
+      </ul>
+      <nav>
+        <Link to="/plan">Planung</Link> |{' '}
+        <Link to="/orders">Bestellungen</Link> |{' '}
+        <Link to="/display">Ladentheke</Link>
+      </nav>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/DisplayCasePage.jsx
+++ b/frontend/src/DisplayCasePage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+const DisplayCasePage = () => {
+  return (
+    <div>
+      <h2>Ladentheke</h2>
+      <p>Hier können Artikelpositionen geplant werden.</p>
+    </div>
+  );
+};
+
+export default DisplayCasePage;

--- a/frontend/src/OrdersPage.jsx
+++ b/frontend/src/OrdersPage.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react';
+
+const OrdersPage = () => {
+  const [orders, setOrders] = useState([]);
+
+  useEffect(() => {
+    fetch('/orders')
+      .then(res => res.json())
+      .then(setOrders)
+      .catch(() => setOrders([]));
+  }, []);
+
+  return (
+    <div>
+      <h2>Bestellungen</h2>
+      <ul>
+        {orders.map(o => (
+          <li key={o.id}>{o.date}: {o.quantity} Stück</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default OrdersPage;

--- a/frontend/src/PlanPage.jsx
+++ b/frontend/src/PlanPage.jsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import { Line } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+const PlanPage = () => {
+  const [preds, setPreds] = useState([]);
+  const [plz, setPlz] = useState('10115');
+  const [weather, setWeather] = useState([]);
+
+  const loadForecast = () => {
+    fetch('/predict', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ branch: 'main', horizon: 7, window: '1D' }),
+    })
+      .then(res => res.json())
+      .then(data => setPreds(data.predictions))
+      .catch(() => setPreds([]));
+
+    fetch(`/weather/${plz}`)
+      .then(res => res.json())
+      .then(setWeather)
+      .catch(() => setWeather([]));
+  };
+
+  const chartData = {
+    labels: preds.map((_, idx) => `Tag ${idx + 1}`),
+    datasets: [
+      {
+        label: 'Forecast',
+        data: preds,
+        borderColor: 'rgb(75, 192, 192)',
+        tension: 0.1,
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h2>Artikelplanung</h2>
+      <button onClick={loadForecast}>Forecast laden</button>
+      {preds.length > 0 && <Line data={chartData} />}
+      {weather.length > 0 && (
+        <ul>
+          {weather.map(w => (
+            <li key={w.date}>{w.date}: {w.temperature.toFixed(1)}°C</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default PlanPage;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- provide stub planning, orders and weather endpoints in backend
- build a simple React UI with routing for dashboard, planning, orders and display-case pages
- show demand forecast and weather in planning page using chart.js

## Testing
- `python -m py_compile main.py`
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684539182b848325a444446c689bea69