### PR TITLE
Add database and local startup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+backend/app.db
+

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ Install dependencies from `backend/requirements.txt` using `pip`.
 
 ## Purpose
 The app is an early prototype that will help bakery managers plan the demand for bread, pastries and other goods for the next days.
+
+## Local Development
+Run `./start_local.sh` from the project root to start both backend and frontend. The script spawns the FastAPI server and the Vite dev server.
+
+The backend stores data in a local SQLite file (`backend/app.db`). To populate it with demo products and sales run:
+
+```bash
+python backend/mock_data.py
+```
+
+## AWS Deployment
+For production we plan to containerize the services with Docker and run them on Amazon EKS. Container images keep the option open to run on EC2 or other services later.

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,49 @@
+from sqlalchemy import create_engine, Column, Integer, String, Date, ForeignKey
+from sqlalchemy.orm import sessionmaker, declarative_base, relationship
+
+DATABASE_URL = "sqlite:///./app.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class Tenant(Base):
+    __tablename__ = "tenants"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+
+    items = relationship("Item", back_populates="tenant")
+    sales = relationship("Sale", back_populates="tenant")
+
+class Item(Base):
+    __tablename__ = "items"
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"))
+    name = Column(String, index=True)
+
+    tenant = relationship("Tenant", back_populates="items")
+    sales = relationship("Sale", back_populates="item")
+
+class Sale(Base):
+    __tablename__ = "sales"
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id"))
+    item_id = Column(Integer, ForeignKey("items.id"))
+    date = Column(Date)
+    quantity = Column(Integer)
+
+    tenant = relationship("Tenant", back_populates="sales")
+    item = relationship("Item", back_populates="sales")
+
+def init_db():
+    Base.metadata.create_all(bind=engine)
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/mock_data.py
+++ b/backend/mock_data.py
@@ -1,0 +1,51 @@
+from datetime import date, timedelta
+import random
+
+from database import SessionLocal, init_db, Tenant, Item, Sale
+
+ITEMS = [
+    "Baguette", "Croissant", "Brot", "Kuchen", "Muffin", "Keks",
+    "Donut", "Bagel", "Brezel", "Tarte", "Ciabatta", "Focaccia",
+    "Scone", "Pita", "Brioche", "Strudel", "Bauernbrot", "Kornspitz",
+    "Streuselschnecke", "Laugenstange"
+]
+
+
+def populate():
+    init_db()
+    db = SessionLocal()
+    if db.query(Tenant).first():
+        print("Database already populated")
+        db.close()
+        return
+
+    tenant = Tenant(name="Demo Bakery")
+    db.add(tenant)
+    db.commit()
+    db.refresh(tenant)
+
+    item_objs = []
+    for name in ITEMS:
+        item = Item(name=name, tenant_id=tenant.id)
+        db.add(item)
+        item_objs.append(item)
+    db.commit()
+
+    start = date.today() - timedelta(weeks=4)
+    for day_offset in range(28):
+        d = start + timedelta(days=day_offset)
+        for item in item_objs:
+            sale = Sale(
+                tenant_id=tenant.id,
+                item_id=item.id,
+                date=d,
+                quantity=random.randint(0, 30)
+            )
+            db.add(sale)
+    db.commit()
+    db.close()
+    print("Inserted demo data")
+
+
+if __name__ == "__main__":
+    populate()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ pydantic
 pandas
 numpy
 neuralforecast
+sqlalchemy

--- a/start_local.sh
+++ b/start_local.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Simple helper to run backend and frontend together
+
+# start backend
+(
+  cd backend || exit 1
+  uvicorn main:app --reload &
+  BACKEND_PID=$!
+)
+
+# start frontend
+(
+  cd frontend || exit 1
+  npm install >/dev/null 2>&1
+  npm run dev &
+  FRONTEND_PID=$!
+)
+
+echo "Backend running with PID $BACKEND_PID"
+echo "Frontend running with PID $FRONTEND_PID"
+
+wait $BACKEND_PID
+wait $FRONTEND_PID


### PR DESCRIPTION
## Summary
- implement simple multi-tenant SQLite database with SQLAlchemy
- add mock data generator for bakery items and recent sales
- expose new `/tenants`, `/tenants/{id}/items` and `/tenants/{id}/sales` endpoints
- include script `start_local.sh` to run backend and frontend together
- document local setup and AWS deployment notes
- ignore local database file in git

## Testing
- `python -m py_compile backend/main.py backend/database.py backend/mock_data.py`
- `bash -n start_local.sh`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68453e48c91c83259f1ec3dedd5446f0